### PR TITLE
Prevent file truncation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,10 @@ fn usage(opts: Options) -> String {
     opts.usage("Usage: rw [options] FILE")
 }
 
-fn pipe(reader: &mut Read, writer: &mut Write) {
+fn pipe(reader: &mut Read, path: &str, append: bool) {
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer).unwrap();
+    let mut writer = open_file(path, append);
     writer.write_all(&buffer).unwrap();
 }
 
@@ -43,13 +44,11 @@ fn main() {
     if matches.opt_present("h") {
         return println!("{}", usage(opts));
     }
-
-    let mut out: Box<Write> = match matches.free.first() {
-        None => Box::new(io::stdout()),
-        Some(file) => {
-            let append = matches.opt_present("a");
-            Box::new(open_file(file, append))
-        }
-    };
-    pipe(&mut io::stdin(), &mut out);
+    let append = matches.opt_present("a");
+    if matches.free.len() != 1 {
+        eprintln!("{}", usage(opts));
+        process::exit(1);
+    }
+    let path = matches.free.first().unwrap();
+    pipe(&mut io::stdin(), path, append);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,9 @@ fn usage(opts: Options) -> String {
 }
 
 fn pipe(reader: &mut Read, writer: &mut Write) {
-    let mut buffer = [0u8; 8 * 1024];
-    while let Ok(n) = reader.read(&mut buffer) {
-        if n == 0 {
-            break;
-        }
-        writer.write_all(&buffer[..n]).unwrap();
-    }
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer).unwrap();
+    writer.write_all(&buffer).unwrap();
 }
 
 fn open_file(path: &str, append: bool) -> File {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,10 @@ fn usage(opts: Options) -> String {
     opts.usage("Usage: rw [options] FILE")
 }
 
-fn pipe(reader: &mut Read, path: Option<&str>, append: bool) {
+fn pipe(reader: &mut impl Read, path: Option<&str>, append: bool) {
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer).unwrap();
-    let mut writer: Box<Write> = match path {
+    let mut writer: Box<dyn Write> = match path {
         None => Box::new(io::stdout()),
         Some(path) => Box::new(open_file(path, append))
     };


### PR DESCRIPTION
### Issue
The file is truncated before the processing is complete.

### Proposed solution
Read everything in memory and move the call to `open_file` after the input is read to completion.